### PR TITLE
fix(savePlayer): return EXIT_FAILURE if there is no player to save

### DIFF
--- a/src/doom_depth.c
+++ b/src/doom_depth.c
@@ -93,7 +93,9 @@ int main_loop(game_window_t * main_window) {
     }
 
     // save player
-    save_player(db, player);
+    if (!save_player(db, player)) {
+        return EXIT_FAILURE;
+    }
 
     save_player_map(player, map);
 

--- a/src/entities/player/player.c
+++ b/src/entities/player/player.c
@@ -165,6 +165,11 @@ void *create_player_from_db(sqlite3_stmt *stmt) {
 
 int save_player(sqlite3 *db, player_t *player) {
 
+    if (!player) {
+        fprintf(stderr, "Player is NULL.\n");
+        return 0;
+    }
+
     char *z_err_msg = NULL;
     sqlite3_stmt *stmt;
 


### PR DESCRIPTION
When there is no player to save, return EXIT_FAILURE
For exemple : when quitting the game before creating or loading one